### PR TITLE
Use assembly.Location as the former is obsolete

### DIFF
--- a/Source/LehmanLaidun.Console/Program.cs
+++ b/Source/LehmanLaidun.Console/Program.cs
@@ -50,7 +50,7 @@ namespace LehmanLaidun.Console
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed(o => options = o);
 
-            Func<string> executingFolder = () => fileSystem.Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase!).LocalPath)!;
+            Func<string> executingFolder = () => fileSystem.Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location!).LocalPath)!;
             Func<string, string> rootedPath = (string path) => fileSystem.Path.GetFullPath(path)!;
             Func<string, string[]> pluginFolders = (string pluginPath) => fileSystem.Directory.GetDirectories(pluginPath);
 


### PR DESCRIPTION
This commit is maintenance to keep the project in shape.